### PR TITLE
Adds test coverage commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log
 artisan
 .gitattributes
 .DS_store
+/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get install -y \
 RUN a2enmod rewrite
 
 # Install PHP extensions
+RUN pecl install pcov \
+    && docker-php-ext-install pdo_mysql zip
 RUN docker-php-ext-install pdo_mysql zip
 
 # Configure Apache DocumentRoot to point to Laravel's public directory

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ migrate-fresh-seed:
 	$(DOCKER_EXEC) php artisan migrate:fresh --seed
 test:
 	$(DOCKER_EXEC) php ./vendor/bin/phpunit
+test-with-coverage:
+	$(DOCKER_EXEC) docker-php-ext-enable pcov && $(DOCKER_EXEC) ./vendor/bin/phpunit --coverage-text
+test-with-coverage-html:
+	$(DOCKER_EXEC) docker-php-ext-enable pcov && $(DOCKER_EXEC) ./vendor/bin/phpunit --coverage-html=coverage && open coverage/index.html
 dump-autoload:
 	$(DOCKER_EXEC) composer dump-autoload
 list-routes:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ http://localhost:3000
 - `make migrate-fresh-seed` - This will blow away and run fresh database migrations.
 - `make build-assets` - This will build the frontend assets for the laravel app.
 - `make test` - This will run tests.
+- `make test-with-coverage` - This will run tests with coverage printed to standard out.
+- `make test-with-coverage-html` - This will run tests with coverage and open the coverage report in a browser.
 
 ### Additional Makefile commands
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
             - "${APP_PORT}:80"
         volumes:
             - app_data:/var/www/html
+            - ./coverage:/var/www/html/coverage
         depends_on:
             sql:
                 condition: service_healthy

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,9 +12,11 @@
             <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+    </coverage>
     <source>
         <include>
-            <directory>app</directory>
+            <directory>./app</directory>
         </include>
     </source>
     <php>
@@ -29,5 +31,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="PHPUNIT_COVERAGE_DRIVER" value="pcov"/>
     </php>
 </phpunit>


### PR DESCRIPTION
## Context

[//]: # (Add context for changes here.)

This PR contains changes to add two Makefile commands.

- `make test-with-coverage` - This will run tests with coverage printed to standard out.
- `make test-with-coverage-html` - This will run tests with coverage and open the coverage report in a browser.

## Changes

[//]: # (Add more detailed info for changes here.)

Changes include:

- Installing `pcov` in `Dockerfile`
- Updates `phpunit.xml` config to consider coverage in `app` folder
- Updates `Makefile` command for both commands described above. 

## Test Checklist

[//]: # (- [ ] Add scenarios.)

- [ ] Verify it builds. 
