### PR TITLE
Adds `GET api/v1/things/{thing_id}`.

### DIFF
--- a/app/Http/Controllers/API/V1/GetThingController.php
+++ b/app/Http/Controllers/API/V1/GetThingController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\API\V1;
+
+use App\Filters\ListThingsFilter;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\API\V1\GetThingRequest;
+use App\Http\Requests\API\V1\GetThingsRequest;
+use App\Http\Resources\API\V1\ThingResource;
+use App\Services\ThingService;
+use Illuminate\Http\JsonResponse;
+
+class GetThingController extends Controller
+{
+    /**
+     * @param ThingService $thingService a service to grab `things` with.
+     */
+    public function __construct(
+        protected readonly ThingService $thingService
+    ) {
+    }
+
+    /**
+     * @param GetThingRequest $request
+     * @return JsonResponse
+     */
+    public function __invoke(
+        GetThingRequest $request
+    ): JsonResponse
+    {
+        return response()->json(
+            ThingResource::make(
+                $this->thingService->find(
+                    $request->input('thing_id')
+                )
+            )
+        );
+    }
+}

--- a/app/Http/Requests/API/V1/GetThingRequest.php
+++ b/app/Http/Requests/API/V1/GetThingRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\API\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetThingRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array[]
+     */
+    public function rules(): array
+    {
+        return [
+            'thing_id' => ['required', 'exists:things,id'],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function prepareForValidation(): void
+    {
+        $this->merge([
+            'thing_id' => $this->route('thing_id'),
+        ]);
+    }
+}

--- a/app/Models/Thing.php
+++ b/app/Models/Thing.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * @method static paginate(int $pageSize)
+ * @method static find(string $thingId)
+ * @property string $id
  * @property string $name
  * @property string $description
  */

--- a/app/Repositories/Database/ThingRepository.php
+++ b/app/Repositories/Database/ThingRepository.php
@@ -11,6 +11,15 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class ThingRepository implements ThingRepositoryInterface
 {
     /**
+     * @param string $thingId
+     * @return Thing
+     */
+    public function find(string $thingId): Thing
+    {
+        return Thing::find($thingId);
+    }
+
+    /**
      * @return Collection
      */
     public function list(): Collection

--- a/app/Services/ThingService.php
+++ b/app/Services/ThingService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Thing;
 use App\Repositories\Database\ThingRepository;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -15,6 +16,16 @@ readonly class ThingService
     public function __construct(
         private ThingRepository $thingRepository
     ) {
+    }
+
+    /**
+     * @param string $thingId
+     * @return Thing
+     */
+    public function find(string $thingId): Thing
+    {
+        return $this->thingRepository
+            ->find($thingId);
     }
 
     /**

--- a/routes/v1/things.php
+++ b/routes/v1/things.php
@@ -2,5 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\V1\GetThingsController;
+use App\Http\Controllers\API\V1\GetThingController;
 
 Route::get('/things', GetThingsController::class);
+Route::get('/things/{thing_id}', GetThingController::class);

--- a/tests/Feature/API/V1/GetThingControllerTest.php
+++ b/tests/Feature/API/V1/GetThingControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\API\V1;
+
+use App\Models\Thing;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetThingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_can_get_thing(): void
+    {
+        $thing = Thing::factory()->create([
+            'name' => 'Test Thing',
+            'description' => 'Test Description',
+        ]);
+
+        $this->get("/api/v1/things/$thing->id")
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'id',
+                'name',
+                'description'
+            ])
+            ->assertJson([
+                    'id' => $thing->id,
+                    'name' => $thing->name,
+                    'description' => $thing->description,
+            ]);
+    }
+}

--- a/tests/Unit/Repositories/Database/ThingRepositoryTest.php
+++ b/tests/Unit/Repositories/Database/ThingRepositoryTest.php
@@ -15,6 +15,24 @@ class ThingRepositoryTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_it_can_find(): void
+    {
+        $repo = new ThingRepository();
+
+        $thing = Thing::factory()->create();
+        $actual = $repo->find($thing->id);
+
+        $this->assertInstanceOf(
+            Thing::class,
+            $actual
+        );
+
+        $this->assertEquals(
+            $thing->id,
+            $actual->id
+        );
+    }
+
     public function test_it_can_list(): void
     {
         $repo = new ThingRepository();
@@ -32,7 +50,7 @@ class ThingRepositoryTest extends TestCase
         );
     }
 
-    public function test_it_can_paginated_list(): void
+    public function test_it_can_get_paginated_list(): void
     {
         $repo = new ThingRepository();
 

--- a/tests/Unit/Services/ThingServiceTest.php
+++ b/tests/Unit/Services/ThingServiceTest.php
@@ -3,14 +3,49 @@
 namespace Tests\Unit\Services;
 
 use App\Filters\ListThingsFilter;
+use App\Models\Thing;
 use App\Repositories\Database\ThingRepository;
 use App\Services\ThingService;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class ThingServiceTest extends TestCase
 {
+    public function test_it_can_find(): void
+    {
+        $thing = Thing::factory()
+            ->make([
+                'id' => Str::uuid()->toString()
+            ]);
+
+        $thingRepo = $this->createMock(
+            ThingRepository::class
+        );
+
+        $thingRepo->expects($this->atLeastOnce())
+            ->method('find')
+            ->with($thing->id)
+            ->willReturn($thing);
+
+        $service = new ThingService(
+            $thingRepo
+        );
+
+        $actual = $service->find($thing->id);
+
+        $this->assertInstanceOf(
+            Thing::class,
+            $actual
+        );
+
+        $this->assertEquals(
+            $thing->id,
+            $actual->id
+        );
+    }
+
     public function test_it_can_list(): void
     {
         $thingRepo = $this->createMock(
@@ -36,7 +71,7 @@ class ThingServiceTest extends TestCase
         );
     }
 
-    public function test_it_can_paginated_list(): void
+    public function test_it_can_get_paginated_list(): void
     {
         $thingRepo = $this->createMock(
             ThingRepository::class


### PR DESCRIPTION
## Context

This PR contains changes to add a `GET api/v1/things` endpoint.

### Example - `GET api/v1/things/{thing_id}` Response Body

```JSON
{
    "id": "9d6b747a-9478-4675-9c19-352636028cab",
    "name": "Test Thing",
    "description": "Test Description"
}
```

## Changes

[//]: # (Add more detailed info for changes here.)

Changes include:
- Adds Request and Controller classes to stand the endpoint up.
- Nudges existing services, repos to grab thing.
- Adds tests assertions.

## Test Checklist

- [ ] Verify it builds.
- [ ] Verify test coverage is adequate.
  - i.e. run `make test-with-coverage`
- [ ] Verify `GET api/v1/things/{thing_id}`.